### PR TITLE
Compress old file on rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,3 @@ Future works
 ------------
 
  * Custom time suffix formats
- * Optional compression of the rotated file

--- a/logr.go
+++ b/logr.go
@@ -40,7 +40,7 @@ func NewWriter(filename string) (*RotatingWriter, error) {
 	return NewWriterFromFile(file)
 }
 
-// NewWriter creates a new file and returns a rotating writer compressing
+// NewWriterWithCompression creates a new file and returns a rotating writer compressing
 // the old files.
 func NewWriterWithCompression(filename string) (*RotatingWriter, error) {
 	w, err := NewWriter(filename)

--- a/logr.go
+++ b/logr.go
@@ -244,18 +244,9 @@ func (w *RotatingWriter) gzip(src *os.File) (*os.File, error) {
 	// compression
 	z := gzip.NewWriter(tmpFile)
 	defer z.Close()
-	tee := io.TeeReader(src, z)
-
-	buff := make([]byte, 64)
-	for {
-		n, err := tee.Read(buff)
-		if err != io.EOF && err != nil {
-			return nil, err
-		}
-
-		if err == io.EOF || n == 0 {
-			break
-		}
+	_, err = io.Copy(z, src)
+	if err != nil {
+		return nil, err
 	}
 
 	return tmpFile, nil

--- a/logr.go
+++ b/logr.go
@@ -177,6 +177,13 @@ func (w *RotatingWriter) rotate() error {
 			if err := w.compressFile(destName); err != nil {
 				return err
 			}
+
+			// no error to compress the data and to rename it
+			// to its last filename, we can now safely remove
+			// the original uncompressed file.
+			if err := os.Remove(destName); err != nil {
+				return err
+			}
 		}
 
 		w.startDate = time.Now().Truncate(time.Hour * 24)
@@ -195,7 +202,7 @@ func (w *RotatingWriter) rotate() error {
 	return nil
 }
 
-// compress rewrites the rotated file in a compressed file.
+// compressFile compresses the file at destName into a file at destName.gz
 func (w *RotatingWriter) compressFile(destName string) error {
 	var rotated, tmpFile *os.File
 	var err error
@@ -219,13 +226,6 @@ func (w *RotatingWriter) compressFile(destName string) error {
 
 	// rename the gzipped file
 	if err := os.Rename(tmpFile.Name(), destName+".gz"); err != nil {
-		return err
-	}
-
-	// no error to compress the data and to rename it
-	// to its last filename, we can now safely remove
-	// the original uncompressed file.
-	if err := os.Remove(destName); err != nil {
 		return err
 	}
 

--- a/logr_test.go
+++ b/logr_test.go
@@ -1,6 +1,8 @@
 package logr_test
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -63,6 +65,60 @@ func TestRotateMaxSize(t *testing.T) {
 
 	rotatedData := readFile(t, f.Name()+"."+now.Format(logr.TimeFormat))
 	require.Nil(t, checkEqual(t, rotatedData, 0xFF))
+}
+
+func TestRotateWithCompression(t *testing.T) {
+	f, err := ioutil.TempFile(os.TempDir(), "logr")
+	require.Nil(t, err)
+
+	rw, err := logr.NewWriterFromFileWithCompression(f)
+	require.Nil(t, err)
+
+	// add some clear text at the beginning of the file
+	text := []byte("This is some clear test at the beginning of the file.")
+
+	now := time.Now()
+	{
+		n, err := rw.Write(text)
+		require.Nil(t, err)
+		require.Equal(t, len(text), n)
+
+		n, err = rw.Write(makeBuf(0xFF))
+		require.Nil(t, err)
+		require.Equal(t, 1024, n)
+
+		rw.MaxSize(512)
+
+		n, err = rw.Write(makeBuf(0xFE))
+		require.Nil(t, err)
+		require.Equal(t, 1024, n)
+	}
+
+	newData := readFile(t, f.Name())
+	require.Nil(t, checkEqual(t, newData, 0xFE))
+
+	{
+		f, err := os.Open(f.Name() + "." + now.Format(logr.TimeFormat) + ".gz")
+		require.Nil(t, err)
+		require.NotNil(t, f)
+
+		rotatedDataGz, err := ioutil.ReadAll(f)
+		require.Nil(t, err)
+		require.NotEqual(t, 0, len(rotatedDataGz))
+
+		// should not be equal cause it has been gzipped
+		require.NotEqual(t, text, rotatedDataGz[:len(text)])
+
+		// gunzip
+		r, err := gzip.NewReader(bytes.NewReader(rotatedDataGz))
+		require.Nil(t, err)
+
+		gunzip, err := ioutil.ReadAll(r)
+		require.Nil(t, err)
+
+		// should be equal cause now gunzipped
+		require.Equal(t, text, gunzip[:len(text)])
+	}
 }
 
 func TestRotateMaxSizeCustomTimeFormat(t *testing.T) {


### PR DESCRIPTION
This PR adds the "compress" option to the RotatingWriter.

It first compresses the old file in gzip then removes the uncompressed one. This behavior needs more disk space but is more safe (the deletion of the original is the last thing done).  Unit tests included.

It would be really nice executed in a goroutine in order to not block during the compression but it's not done in this PR: in a goroutine, it'll be hard to return an error on compression. Up to you.

The "actual" compression is done in the `gzip` method, this way you can easily change the compression algorithm to your needs.
